### PR TITLE
Adjust AudioSource pitch by comparing AudioSettings and Csound sr 

### DIFF
--- a/Editor/CsoundUnityEditor.cs
+++ b/Editor/CsoundUnityEditor.cs
@@ -45,7 +45,7 @@ public class CsoundUnityEditor : Editor
     SerializedProperty m_csoundString;
     SerializedProperty m_csoundScore;
     SerializedProperty m_processAudio;
-	SerializedProperty m_sampleRate;
+    SerializedProperty m_sampleRate;
     SerializedProperty m_mute;
     SerializedProperty m_logCsoundOutput;
     SerializedProperty m_loudVolumeWarning;
@@ -75,7 +75,7 @@ public class CsoundUnityEditor : Editor
         m_csoundString = this.serializedObject.FindProperty("_csoundString");
         m_csoundScore = this.serializedObject.FindProperty("csoundScore");
         m_processAudio = this.serializedObject.FindProperty("processClipAudio");
-		m_sampleRate = this.serializedObject.FindProperty("sampleRate");
+        m_sampleRate = this.serializedObject.FindProperty("sampleRate");
         m_mute = this.serializedObject.FindProperty("mute");
         m_logCsoundOutput = this.serializedObject.FindProperty("logCsoundOutput");
         m_loudVolumeWarning = this.serializedObject.FindProperty("loudVolumeWarning");
@@ -135,7 +135,7 @@ public class CsoundUnityEditor : Editor
         if (m_drawSettings.boolValue)
         {
             EditorGUI.BeginChangeCheck();
-			m_sampleRate.intValue = EditorGUILayout.IntField("Sample Rate", m_sampleRate.intValue);
+            m_sampleRate.intValue = EditorGUILayout.IntField("Sample Rate", m_sampleRate.intValue);
             m_processAudio.boolValue = EditorGUILayout.Toggle("Process Clip Audio", m_processAudio.boolValue);
             if (EditorGUI.EndChangeCheck())
             {

--- a/Editor/CsoundUnityEditor.cs
+++ b/Editor/CsoundUnityEditor.cs
@@ -45,6 +45,7 @@ public class CsoundUnityEditor : Editor
     SerializedProperty m_csoundString;
     SerializedProperty m_csoundScore;
     SerializedProperty m_processAudio;
+	SerializedProperty m_sampleRate;
     SerializedProperty m_mute;
     SerializedProperty m_logCsoundOutput;
     SerializedProperty m_loudVolumeWarning;
@@ -74,6 +75,7 @@ public class CsoundUnityEditor : Editor
         m_csoundString = this.serializedObject.FindProperty("_csoundString");
         m_csoundScore = this.serializedObject.FindProperty("csoundScore");
         m_processAudio = this.serializedObject.FindProperty("processClipAudio");
+		m_sampleRate = this.serializedObject.FindProperty("sampleRate");
         m_mute = this.serializedObject.FindProperty("mute");
         m_logCsoundOutput = this.serializedObject.FindProperty("logCsoundOutput");
         m_loudVolumeWarning = this.serializedObject.FindProperty("loudVolumeWarning");
@@ -133,6 +135,7 @@ public class CsoundUnityEditor : Editor
         if (m_drawSettings.boolValue)
         {
             EditorGUI.BeginChangeCheck();
+			m_sampleRate.intValue = EditorGUILayout.IntField("Sample Rate", m_sampleRate.intValue);
             m_processAudio.boolValue = EditorGUILayout.Toggle("Process Clip Audio", m_processAudio.boolValue);
             if (EditorGUI.EndChangeCheck())
             {

--- a/Runtime/CsoundUnity.cs
+++ b/Runtime/CsoundUnity.cs
@@ -250,6 +250,13 @@ public class CsoundUnity : MonoBehaviour
     /// If false, no processing occurs on the attached AudioClip
     /// </summary>
     [HideInInspector] public bool processClipAudio;
+	
+	/// <summary>
+    /// Sample Rate of the Csound instance
+    /// Used to calculate AudioSource pitch offset
+	/// Ensures that OnAudioFilterRead runs at/near the same rate as Csound
+    /// </summary>
+	[HideInInspector] public int sampleRate = 48000;
 
     /// <summary>
     /// If true it will print warnings in the console when the output volume is too high, 
@@ -398,7 +405,8 @@ public class CsoundUnity : MonoBehaviour
         /// the CsoundUnityBridge constructor the string with the csound code and a list of the Global Environment Variables Settings.
         /// It then calls createCsound() to create an instance of Csound and compile the csd string.
         /// After this we start the performance of Csound.
-        csound = new CsoundUnityBridge(_csoundString, environmentSettings);
+        csound = new CsoundUnityBridge(_csoundString, environmentSettings, sampleRate);
+		SetAudioSourcePitch();
         if (csound != null)
         {
             /// channels are created when a csd file is selected in the inspector
@@ -1473,6 +1481,20 @@ public class CsoundUnity : MonoBehaviour
 
 
     #region PRIVATE_METHODS
+	
+	private void SetAudioSourcePitch()
+	{
+		if (!audioSource)
+		{
+			audioSource = GetComponent<AudioSource>();
+		}
+		audioSource.pitch = ((float)sampleRate / AudioSettings.outputSampleRate);
+	}
+
+	private void OnValidate()
+	{
+		SetAudioSourcePitch();
+	}
 
     void OnAudioFilterRead(float[] data, int channels)
     {

--- a/Runtime/CsoundUnity.cs
+++ b/Runtime/CsoundUnity.cs
@@ -251,12 +251,12 @@ public class CsoundUnity : MonoBehaviour
     /// </summary>
     [HideInInspector] public bool processClipAudio;
 	
-	/// <summary>
+    /// <summary>
     /// Sample Rate of the Csound instance
     /// Used to calculate AudioSource pitch offset
-	/// Ensures that OnAudioFilterRead runs at/near the same rate as Csound
+    /// Ensures that OnAudioFilterRead runs at/near the same rate as Csound
     /// </summary>
-	[HideInInspector] public int sampleRate = 48000;
+    [HideInInspector] public int sampleRate = 48000;
 
     /// <summary>
     /// If true it will print warnings in the console when the output volume is too high, 
@@ -406,7 +406,7 @@ public class CsoundUnity : MonoBehaviour
         /// It then calls createCsound() to create an instance of Csound and compile the csd string.
         /// After this we start the performance of Csound.
         csound = new CsoundUnityBridge(_csoundString, environmentSettings, sampleRate);
-		SetAudioSourcePitch();
+        SetAudioSourcePitch();
         if (csound != null)
         {
             /// channels are created when a csd file is selected in the inspector
@@ -1482,19 +1482,19 @@ public class CsoundUnity : MonoBehaviour
 
     #region PRIVATE_METHODS
 	
-	private void SetAudioSourcePitch()
-	{
-		if (!audioSource)
-		{
-			audioSource = GetComponent<AudioSource>();
-		}
-		audioSource.pitch = ((float)sampleRate / AudioSettings.outputSampleRate);
-	}
+    private void SetAudioSourcePitch()
+    {
+        if (!audioSource)
+        {
+            audioSource = GetComponent<AudioSource>();
+        }
+        audioSource.pitch = ((float)sampleRate / AudioSettings.outputSampleRate);
+    }
 
-	private void OnValidate()
-	{
-		SetAudioSourcePitch();
-	}
+    private void OnValidate()
+    {
+        SetAudioSourcePitch();
+    }
 
     void OnAudioFilterRead(float[] data, int channels)
     {

--- a/Runtime/CsoundUnityBridge.cs
+++ b/Runtime/CsoundUnityBridge.cs
@@ -94,7 +94,7 @@ public class CsoundUnityBridge
     /// </summary>
     /// <param name="csdFile">The Csound (.csd) file content as a string</param>
     /// <param name="environmentSettings">A list of the Csound Environments settings defined by the user</param>
-    public CsoundUnityBridge(string csdFile, List<EnvironmentSettings> environmentSettings)
+    public CsoundUnityBridge(string csdFile, List<EnvironmentSettings> environmentSettings, int sampleRate)
     {
          SetEnvironmentSettings(environmentSettings);
 
@@ -124,8 +124,8 @@ public class CsoundUnityBridge
         Csound6.NativeMethods.csoundSetOption(csound, "-d");
 
         var parms = GetParams();
-        parms.control_rate_override = AudioSettings.outputSampleRate;
-        parms.sample_rate_override = AudioSettings.outputSampleRate;
+        parms.control_rate_override = sampleRate;
+        parms.sample_rate_override = sampleRate;
         SetParams(parms);
 
         int ret = Csound6.NativeMethods.csoundCompileCsdText(csound, csdFile);

--- a/Runtime/CsoundUnityChild.cs
+++ b/Runtime/CsoundUnityChild.cs
@@ -108,7 +108,7 @@ public class CsoundUnityChild : MonoBehaviour
         audioSource.velocityUpdateMode = AudioVelocityUpdateMode.Fixed;
         audioSource.spatialBlend = 1.0f;
         audioSource.spatializePostEffects = true;
-		audioSource.pitch = ((float)csoundUnity.sampleRate / AudioSettings.outputSampleRate);
+        audioSource.pitch = ((float)csoundUnity.sampleRate / AudioSettings.outputSampleRate);
 
         // this will invert the audio channels
         // 0---------180-----360

--- a/Runtime/CsoundUnityChild.cs
+++ b/Runtime/CsoundUnityChild.cs
@@ -108,6 +108,7 @@ public class CsoundUnityChild : MonoBehaviour
         audioSource.velocityUpdateMode = AudioVelocityUpdateMode.Fixed;
         audioSource.spatialBlend = 1.0f;
         audioSource.spatializePostEffects = true;
+		audioSource.pitch = ((float)csoundUnity.sampleRate / AudioSettings.outputSampleRate);
 
         // this will invert the audio channels
         // 0---------180-----360


### PR DESCRIPTION
Found that adjusting the pitch of an AudioSource reduces the rate at which OnAudioFilterRead is called.  This allows for a lower sample rate to be used in the Csound instance and Unity will read from said instance at the appropriate sample rate.  Allows for major improvement in resource consumption when less than high quality audio required.

Need to test this out on a more recent Unity version tomorrow, am running an older version of Unity (2019.4.9f1).  Will verify all is good in more recent versions tomorrow evening.