### PR TITLE
Fix: v3.5.1 installation with visionOS support

### DIFF
--- a/Runtime/CsoundUnity.cs
+++ b/Runtime/CsoundUnity.cs
@@ -294,7 +294,7 @@ public class CsoundUnity : MonoBehaviour
     /// <summary>
     /// The version of this package
     /// </summary>
-    public const string packageVersion = "3.5.0";
+    public const string packageVersion = "3.5.1";
 
     /// <summary>
     /// the unique guid of the csd file

--- a/Runtime/visionOS.meta
+++ b/Runtime/visionOS.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ecf98f6ec06f44b59cf4a0fb67391231
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.csound.csoundunity",
   "displayName": "CsoundUnity",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "unity": "2018.1",
   "description": "CsoundUnity is a fully integrated audio middleware. \nIt extends Unity's audio API by creating Csound-based AudioSource objects that can interact and exist alongside regular AudioSource objects. \nWith CsoundUnity, games developers have at their fingertips one of the most powerful synthesis systems in existence. \n\nPlease visit homepage: http://rorywalsh.github.io/CsoundUnity/ \n\nThis interface would not have been possible without Richard Henninger's .NET interface to the Csound API.",
   "samples": [


### PR DESCRIPTION
This PR fixes issues installing CsoundUnity v3.5.1 via Git URL in Unity Package Manager.

**Observed Problem:**
- Installing via Git URL resulted in v3.5.0 instead of v3.5.1.
- Missing `Runtime/visionOS.meta` caused errors (related to #72).